### PR TITLE
Refactor CLI utils and add docs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,3 @@
-/*
-Copyright © 2025 NAME HERE <EMAIL ADDRESS>
-*/
 package cmd
 
 import (
@@ -9,11 +6,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// rootCmd represents the base command when called without any subcommands
+// rootCmd represents the base command when called without any subcommands.
+// It provides common configuration and flags for all subcommands.
 var rootCmd = &cobra.Command{
-	Use:   "labra",
-	Short: "cli tool for LabraGo",
-	Long:  `cli tool to create and start a labraGo project`,
+	Use:   "labractl",
+	Short: "CLI tool for LabraGo",
+	Long:  `CLI tool to create and start a LabraGo project`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -8,8 +8,11 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+
+	"github.com/GoLabra/labractl/internal/cliutils"
 )
 
+// startCmd runs the LabraGo backend and frontend concurrently.
 var startCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start both backend and frontend servers",
@@ -22,7 +25,7 @@ var startCmd = &cobra.Command{
 		// 1. If no package.json, run `yarn init -y`
 		if _, err := os.Stat(packageJsonPath); err != nil {
 			fmt.Println("📦 No package.json found. Initializing Yarn project...")
-			if err := runCommand("yarn", []string{"init", "-y"}, root); err != nil {
+			if err := cliutils.RunCommand("yarn", []string{"init", "-y"}, root); err != nil {
 				fmt.Println("❌ Failed to initialize Yarn project:", err)
 				os.Exit(1)
 			}
@@ -71,7 +74,7 @@ var startCmd = &cobra.Command{
 		// 4. Check/install concurrently
 		if err := exec.Command("yarn", "list", "--pattern", "concurrently").Run(); err != nil {
 			fmt.Println("📦 Installing concurrently...")
-			if err := runCommand("yarn", []string{"add", "concurrently", "--dev"}, root); err != nil {
+			if err := cliutils.RunCommand("yarn", []string{"add", "concurrently", "--dev"}, root); err != nil {
 				fmt.Println("❌ Failed to install concurrently:", err)
 				os.Exit(1)
 			}
@@ -90,6 +93,7 @@ var startCmd = &cobra.Command{
 	},
 }
 
+// init registers the start command with the root command.
 func init() {
 	rootCmd.AddCommand(startCmd)
 }

--- a/internal/cliutils/exec.go
+++ b/internal/cliutils/exec.go
@@ -1,0 +1,28 @@
+// Package cliutils contains helper utilities shared across CLI commands.
+package cliutils
+
+import (
+	"bufio"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// RunCommand executes a command with the provided arguments inside a
+// working directory. Stdout and stderr are attached to the current
+// process so output streams to the user.
+func RunCommand(bin string, args []string, dir string) error {
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// ReadLine reads a single line from STDIN and trims any trailing
+// newline characters. It is used when prompting the user for input.
+func ReadLine() string {
+	reader := bufio.NewReader(os.Stdin)
+	line, _ := reader.ReadString('\n')
+	return strings.TrimSpace(line)
+}

--- a/main.go
+++ b/main.go
@@ -1,10 +1,9 @@
-/*
-Copyright © 2025 NAME HERE <EMAIL ADDRESS>
-*/
+// Binary entrypoint for labractl.
 package main
 
 import "github.com/GoLabra/labractl/cmd"
 
+// main is the application entry point.
 func main() {
 	cmd.Execute()
 }


### PR DESCRIPTION
## Summary
- extract common functions to `internal/cliutils`
- update `rootCmd` usage string
- document CLI packages and functions

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687e42b30148832ca62f73749626d452