### PR TITLE
Add Windows compatibility

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -17,16 +17,16 @@ var startCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start both backend and frontend servers",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("🚦 Preparing LabraGo start...")
+		fmt.Println(cliutils.Emoji("🚦", "->"), "Preparing LabraGo start...")
 
 		root := "."
 		packageJsonPath := filepath.Join(root, "package.json")
 
 		// 1. If no package.json, run `yarn init -y`
 		if _, err := os.Stat(packageJsonPath); err != nil {
-			fmt.Println("📦 No package.json found. Initializing Yarn project...")
+			fmt.Println(cliutils.Emoji("📦", "[pkg]"), "No package.json found. Initializing Yarn project...")
 			if err := cliutils.RunCommand("yarn", []string{"init", "-y"}, root); err != nil {
-				fmt.Println("❌ Failed to initialize Yarn project:", err)
+				fmt.Println(cliutils.Emoji("❌", "X"), "Failed to initialize Yarn project:", err)
 				os.Exit(1)
 			}
 		}
@@ -34,21 +34,23 @@ var startCmd = &cobra.Command{
 		// 2. Read + parse package.json
 		data, err := os.ReadFile(packageJsonPath)
 		if err != nil {
-			fmt.Println("❌ Failed to read package.json:", err)
+			fmt.Println(cliutils.Emoji("❌", "X"), "Failed to read package.json:", err)
 			os.Exit(1)
 		}
 
 		var pkg map[string]interface{}
 		if err := json.Unmarshal(data, &pkg); err != nil {
-			fmt.Println("❌ Failed to parse package.json:", err)
+			fmt.Println(cliutils.Emoji("❌", "X"), "Failed to parse package.json:", err)
 			os.Exit(1)
 		}
 
 		// 3. Add missing scripts
+		backendPath := filepath.Join("src", "app")
+		frontendPath := filepath.Join("src", "admin")
 		scripts := map[string]string{
 			"start":          "concurrently \"yarn start:backend\" \"yarn start:frontend\"",
-			"start:backend":  "cd src/app && go run main.go start",
-			"start:frontend": "cd src/admin && yarn dev",
+			"start:backend":  fmt.Sprintf("cd %s && go run main.go start", backendPath),
+			"start:frontend": fmt.Sprintf("cd %s && yarn dev", frontendPath),
 		}
 		modified := false
 		if pkg["scripts"] == nil {
@@ -65,29 +67,29 @@ var startCmd = &cobra.Command{
 		if modified {
 			newData, _ := json.MarshalIndent(pkg, "", "  ")
 			if err := os.WriteFile(packageJsonPath, newData, 0644); err != nil {
-				fmt.Println("❌ Failed to update package.json:", err)
+				fmt.Println(cliutils.Emoji("❌", "X"), "Failed to update package.json:", err)
 				os.Exit(1)
 			}
-			fmt.Println("🛠 package.json updated with start scripts.")
+			fmt.Println(cliutils.Emoji("🛠", "[update]"), "package.json updated with start scripts.")
 		}
 
 		// 4. Check/install concurrently
 		if err := exec.Command("yarn", "list", "--pattern", "concurrently").Run(); err != nil {
-			fmt.Println("📦 Installing concurrently...")
+			fmt.Println(cliutils.Emoji("📦", "[pkg]"), "Installing concurrently...")
 			if err := cliutils.RunCommand("yarn", []string{"add", "concurrently", "--dev"}, root); err != nil {
-				fmt.Println("❌ Failed to install concurrently:", err)
+				fmt.Println(cliutils.Emoji("❌", "X"), "Failed to install concurrently:", err)
 				os.Exit(1)
 			}
 		}
 
 		// 5. Run yarn start
-		fmt.Println("🚀 Starting LabraGo backend + frontend")
+		fmt.Println(cliutils.Emoji("🚀", "->"), "Starting LabraGo backend + frontend")
 		run := exec.Command("yarn", "start")
 		run.Stdout = os.Stdout
 		run.Stderr = os.Stderr
 		run.Stdin = os.Stdin
 		if err := run.Run(); err != nil {
-			fmt.Println("❌ Failed to run yarn start:", err)
+			fmt.Println(cliutils.Emoji("❌", "X"), "Failed to run yarn start:", err)
 			os.Exit(1)
 		}
 	},

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/GoLabra/labractl/internal/cliutils"
+	"github.com/spf13/cobra"
+)
+
+// version is set at build time using -ldflags.
+var version = "dev"
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print labractl version",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(cliutils.Emoji("🧰", "version:"), version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/cmd/windows_test.go
+++ b/cmd/windows_test.go
@@ -1,0 +1,11 @@
+//go:build windows
+
+package cmd
+
+import "testing"
+
+func TestGetInstallCommandWindows(t *testing.T) {
+	if c := getInstallCommand("git", "windows"); c == nil {
+		t.Fatal("expected command for windows")
+	}
+}

--- a/internal/cliutils/compat.go
+++ b/internal/cliutils/compat.go
@@ -1,0 +1,15 @@
+package cliutils
+
+import "runtime"
+
+// IsWindows reports whether the CLI is running on Windows.
+var IsWindows = runtime.GOOS == "windows"
+
+// Emoji returns the symbol if the terminal likely supports it, or a fallback
+// ASCII representation on Windows where emoji support may be limited.
+func Emoji(symbol, fallback string) string {
+	if IsWindows {
+		return fallback
+	}
+	return symbol
+}

--- a/internal/cliutils/exec.go
+++ b/internal/cliutils/exec.go
@@ -5,6 +5,7 @@ import (
 	"bufio"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 )
 
@@ -12,7 +13,14 @@ import (
 // working directory. Stdout and stderr are attached to the current
 // process so output streams to the user.
 func RunCommand(bin string, args []string, dir string) error {
-	cmd := exec.Command(bin, args...)
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		// Use cmd.exe for better built-in command compatibility
+		all := append([]string{bin}, args...)
+		cmd = exec.Command("cmd", append([]string{"/C"}, all...)...)
+	} else {
+		cmd = exec.Command(bin, args...)
+	}
 	cmd.Dir = dir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
## Summary
- add Windows detection helpers
- wrap shell commands in `cmd.exe` on Windows
- add emoji fallback for Windows
- create `version` command
- add Windows-only test case

## Testing
- `go test ./...`
- `GOOS=windows go test ./...` *(fails: exec format error)*

------
https://chatgpt.com/codex/tasks/task_e_687e56cbaf70832c8b858f054b122d4e