### PR TITLE
Add structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ This will:
     - Backend: `cd src/app && go run main.go start`
     - Frontend: `cd src/admin && yarn dev`
 
+Verbose logs can be enabled with `--debug` or by setting `LABRA_DEBUG=1`.
+
 ---
 
 ## 🛠 Development

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,8 +2,11 @@ package cmd
 
 import (
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/GoLabra/labractl/internal/log"
 )
 
 // rootCmd represents the base command when called without any subcommands.
@@ -17,11 +20,16 @@ var rootCmd = &cobra.Command{
 	// Run: func(cmd *cobra.Command, args []string) { },
 }
 
+var debug bool
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
+	envDebug := strings.ToLower(os.Getenv("LABRA_DEBUG"))
+	enableDebug := debug || envDebug == "1" || envDebug == "true"
+	log.Init(enableDebug)
+
+	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}
 }
@@ -36,4 +44,5 @@ func init() {
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "", false, "Enable debug logs")
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/GoLabra/labractl/internal/cliutils"
+	"github.com/GoLabra/labractl/internal/log"
 )
 
 // startCmd runs the LabraGo backend and frontend concurrently.
@@ -17,16 +17,16 @@ var startCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start both backend and frontend servers",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("🚦 Preparing LabraGo start...")
+		log.Infof("🚦 Preparing LabraGo start...")
 
 		root := "."
 		packageJsonPath := filepath.Join(root, "package.json")
 
 		// 1. If no package.json, run `yarn init -y`
 		if _, err := os.Stat(packageJsonPath); err != nil {
-			fmt.Println("📦 No package.json found. Initializing Yarn project...")
+			log.Infof("📦 No package.json found. Initializing Yarn project...")
 			if err := cliutils.RunCommand("yarn", []string{"init", "-y"}, root); err != nil {
-				fmt.Println("❌ Failed to initialize Yarn project:", err)
+				log.Errorf("❌ Failed to initialize Yarn project: %v", err)
 				os.Exit(1)
 			}
 		}
@@ -34,13 +34,13 @@ var startCmd = &cobra.Command{
 		// 2. Read + parse package.json
 		data, err := os.ReadFile(packageJsonPath)
 		if err != nil {
-			fmt.Println("❌ Failed to read package.json:", err)
+			log.Errorf("❌ Failed to read package.json: %v", err)
 			os.Exit(1)
 		}
 
 		var pkg map[string]interface{}
 		if err := json.Unmarshal(data, &pkg); err != nil {
-			fmt.Println("❌ Failed to parse package.json:", err)
+			log.Errorf("❌ Failed to parse package.json: %v", err)
 			os.Exit(1)
 		}
 
@@ -65,29 +65,29 @@ var startCmd = &cobra.Command{
 		if modified {
 			newData, _ := json.MarshalIndent(pkg, "", "  ")
 			if err := os.WriteFile(packageJsonPath, newData, 0644); err != nil {
-				fmt.Println("❌ Failed to update package.json:", err)
+				log.Errorf("❌ Failed to update package.json: %v", err)
 				os.Exit(1)
 			}
-			fmt.Println("🛠 package.json updated with start scripts.")
+			log.Infof("🛠 package.json updated with start scripts.")
 		}
 
 		// 4. Check/install concurrently
 		if err := exec.Command("yarn", "list", "--pattern", "concurrently").Run(); err != nil {
-			fmt.Println("📦 Installing concurrently...")
+			log.Infof("📦 Installing concurrently...")
 			if err := cliutils.RunCommand("yarn", []string{"add", "concurrently", "--dev"}, root); err != nil {
-				fmt.Println("❌ Failed to install concurrently:", err)
+				log.Errorf("❌ Failed to install concurrently: %v", err)
 				os.Exit(1)
 			}
 		}
 
 		// 5. Run yarn start
-		fmt.Println("🚀 Starting LabraGo backend + frontend")
+		log.Infof("🚀 Starting LabraGo backend + frontend")
 		run := exec.Command("yarn", "start")
 		run.Stdout = os.Stdout
 		run.Stderr = os.Stderr
 		run.Stdin = os.Stdin
 		if err := run.Run(); err != nil {
-			fmt.Println("❌ Failed to run yarn start:", err)
+			log.Errorf("❌ Failed to run yarn start: %v", err)
 			os.Exit(1)
 		}
 	},

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,0 +1,46 @@
+package log
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+)
+
+var Logger *slog.Logger
+
+// Init configures the logger with the provided debug flag.
+func Init(debug bool) {
+	level := slog.LevelInfo
+	if debug {
+		level = slog.LevelDebug
+	}
+	Logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
+}
+
+func Debugf(format string, args ...any) {
+	if Logger == nil {
+		Init(false)
+	}
+	Logger.Debug(fmt.Sprintf(format, args...))
+}
+
+func Infof(format string, args ...any) {
+	if Logger == nil {
+		Init(false)
+	}
+	Logger.Info(fmt.Sprintf(format, args...))
+}
+
+func Warnf(format string, args ...any) {
+	if Logger == nil {
+		Init(false)
+	}
+	Logger.Warn(fmt.Sprintf(format, args...))
+}
+
+func Errorf(format string, args ...any) {
+	if Logger == nil {
+		Init(false)
+	}
+	Logger.Error(fmt.Sprintf(format, args...))
+}


### PR DESCRIPTION
## Summary
- add `internal/log` package for structured logging
- support `--debug`/`LABRA_DEBUG` environment variable
- replace `fmt` prints with log calls
- document how to enable verbose logs

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_687e5a55e9a8832c83a75e7b9ad3dc37