### PR TITLE
Feature/upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,9 @@ labractl start
 ```
 
 This launches:
-- 🖥️ **Backend server** on `http://localhost:4001`
+- 🖥️ **Backend server** on `http://localhost:4000`
 - 🎨 **Frontend admin** on `http://localhost:3000`
-- 🔍 **GraphQL Playground** on `http://localhost:4001/playground`
+- 🔍 **GraphQL Playground** on `http://localhost:4000/playground`
 
 ## 📖 Detailed Usage
 
@@ -115,7 +115,7 @@ labractl create myproject --debug
 **What happens during creation:**
 1. **Repository cloning** from `https://github.com/GoLabra/labra`
 2. **Go module configuration** with local API replacement
-3. **Environment setup** with backend and frontend `.env` files
+3. **Environment setup** with backend `.env` and frontend `.env.local` files
 4. **Dependency installation** using your preferred package manager
 5. **Database initialization** with PostgreSQL user and database
 6. **Code generation** with `go mod tidy` and `go generate`

--- a/README.md
+++ b/README.md
@@ -113,12 +113,14 @@ labractl create myproject --debug
 ```
 
 **What happens during creation:**
-1. **Repository cloning** from `https://github.com/GoLabra/labra`
-2. **Go module configuration** with local API replacement
-3. **Environment setup** with backend `.env` and frontend `.env.local` files
-4. **Dependency installation** using your preferred package manager
-5. **Database initialization** with PostgreSQL user and database
-6. **Code generation** with `go mod tidy` and `go generate`
+1. **Repository cloning** from `https://github.com/GoLabra/labra` to cache directory
+2. **Template copying** - Only `resources/app/*` contents are copied to project root
+3. **Admin setup** - `resources/admin/*` contents are copied to `admin/` subdirectory
+4. **Go module configuration** with local API replacement pointing to cached labra repo
+5. **Environment setup** with backend `.env` and frontend `.env.local` files
+6. **Dependency installation** using your preferred package manager
+7. **Database initialization** with PostgreSQL user and database
+8. **Code generation** with `go mod tidy` and `go generate`
 
 ### **Development Server**
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -32,25 +33,82 @@ var createCmd = &cobra.Command{
 		// 2. Choose package manager
 		packageManager := choosePackageManager()
 
-		// 3. Clone repo (optionally at a specific ref)
-		cloneArgs := []string{"clone", repoURL, projectName}
-		if strings.TrimSpace(labraRef) != "" {
-			log.Infof("🌿 Using Labra ref: %s", labraRef)
-			cloneArgs = []string{"clone", "--branch", labraRef, "--single-branch", repoURL, projectName}
-		}
-		if err := cliutils.RunCommand("git", cloneArgs, ""); err != nil {
-			log.Errorf("❌ Git clone failed: %v", err)
+		// 3. Create project directory
+		if err := os.MkdirAll(projectName, 0755); err != nil {
+			log.Errorf("❌ Failed to create project directory: %v", err)
 			os.Exit(1)
 		}
 
-		// 4. Patch go.mod
-		goModPath := filepath.Join(projectName, "resources", "app", "go.mod")
-		if err := patchGoMod(goModPath); err != nil {
+		// 4. Clone repo to cache location (persistent for go.mod replace)
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			log.Errorf("❌ Failed to get home directory: %v", err)
+			os.Exit(1)
+		}
+		cacheDir := filepath.Join(homeDir, ".cache", "labractl")
+		if err := os.MkdirAll(cacheDir, 0755); err != nil {
+			log.Errorf("❌ Failed to create cache directory: %v", err)
+			os.Exit(1)
+		}
+
+		// Use ref in cache directory name to support multiple versions
+		cacheRepoName := "labra"
+		if strings.TrimSpace(labraRef) != "" {
+			// Sanitize ref name for filesystem
+			sanitizedRef := strings.ReplaceAll(strings.ReplaceAll(labraRef, "/", "-"), "\\", "-")
+			cacheRepoName = fmt.Sprintf("labra-%s", sanitizedRef)
+			log.Infof("🌿 Using Labra ref: %s", labraRef)
+		}
+		cacheRepoPath := filepath.Join(cacheDir, cacheRepoName)
+
+		// Clone if not already cached, or update if ref changed
+		if _, err := os.Stat(cacheRepoPath); os.IsNotExist(err) {
+			cloneArgs := []string{"clone", repoURL, cacheRepoPath}
+			if strings.TrimSpace(labraRef) != "" {
+				cloneArgs = []string{"clone", "--branch", labraRef, "--single-branch", repoURL, cacheRepoPath}
+			}
+			if err := cliutils.RunCommand("git", cloneArgs, ""); err != nil {
+				log.Errorf("❌ Git clone failed: %v", err)
+				os.Exit(1)
+			}
+		} else if strings.TrimSpace(labraRef) != "" {
+			// Update existing clone if ref specified
+			if err := cliutils.RunCommand("git", []string{"fetch", "origin", labraRef}, cacheRepoPath); err == nil {
+				_ = cliutils.RunCommand("git", []string{"checkout", labraRef}, cacheRepoPath)
+			}
+		}
+
+		// 5. Copy resources/app/* to project root
+		appSource := filepath.Join(cacheRepoPath, "resources", "app")
+		if err := copyDirectory(appSource, projectName); err != nil {
+			log.Errorf("❌ Failed to copy app template: %v", err)
+			os.Exit(1)
+		}
+
+		// 6. Copy resources/admin/* to projectName/admin/
+		adminSource := filepath.Join(cacheRepoPath, "resources", "admin")
+		adminDest := filepath.Join(projectName, "admin")
+		if _, err := os.Stat(adminSource); err == nil {
+			if err := copyDirectory(adminSource, adminDest); err != nil {
+				log.Warnf("⚠️ Failed to copy admin template: %v", err)
+			}
+		}
+
+		// 7. Get absolute path to labra repo for go.mod replace
+		labraRepoPath, err := filepath.Abs(cacheRepoPath)
+		if err != nil {
+			log.Errorf("❌ Failed to get absolute path: %v", err)
+			os.Exit(1)
+		}
+
+		// 8. Patch go.mod
+		goModPath := filepath.Join(projectName, "go.mod")
+		if err := patchGoMod(goModPath, labraRepoPath); err != nil {
 			log.Errorf("❌ go.mod patch failed: %v", err)
 			os.Exit(1)
 		}
 
-		// 5. Create .env files
+		// 9. Create .env files
 		if err := createAppEnvFile(projectName); err != nil {
 			log.Errorf("❌ Backend .env failed: %v", err)
 			os.Exit(1)
@@ -60,50 +118,110 @@ var createCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		// 6. Go mod tidy + generate
-		appPath := filepath.Join(projectName, "resources", "app")
-		_ = cliutils.RunCommand("go", []string{"mod", "tidy"}, appPath)
-		if err := cliutils.RunCommand("go", []string{"generate", "./..."}, appPath); err != nil {
+		// 10. Go mod tidy + generate
+		_ = cliutils.RunCommand("go", []string{"mod", "tidy"}, projectName)
+		if err := cliutils.RunCommand("go", []string{"generate", "./..."}, projectName); err != nil {
 			log.Warnf("⚠️ go generate failed, retrying...")
-			_ = cliutils.RunCommand("go", []string{"mod", "tidy"}, appPath)
-			_ = cliutils.RunCommand("go", []string{"generate", "./..."}, appPath)
+			_ = cliutils.RunCommand("go", []string{"mod", "tidy"}, projectName)
+			_ = cliutils.RunCommand("go", []string{"generate", "./..."}, projectName)
 		}
 
-		// 7. Frontend install
-		adminPath := filepath.Join(projectName, "resources", "admin")
+		// 11. Frontend install
+		adminPath := filepath.Join(projectName, "admin")
 		if _, err := os.Stat(filepath.Join(adminPath, "package.json")); err == nil {
 			log.Infof("📦 Installing frontend dependencies with %s...", packageManager)
 			_ = cliutils.RunCommand(packageManager, []string{"install"}, adminPath)
 		}
 
-		// 8. Ensure PostgreSQL
+		// 12. Ensure PostgreSQL
 		if err := ensurePostgresUserAndDatabase(projectName); err != nil {
 			log.Warnf("⚠️ PostgreSQL setup failed: %v", err)
 		}
 
-		// 9. Done
+		// 13. Done
 		log.Infof("✅ Project created at %s", projectName)
 		log.Infof("👉 cd %s\nlabractl start", projectName)
 	},
 }
 
+// copyDirectory recursively copies a directory from source to destination.
+func copyDirectory(src, dst string) error {
+	// Create destination directory
+	if err := os.MkdirAll(dst, 0755); err != nil {
+		return fmt.Errorf("failed to create destination directory: %w", err)
+	}
+
+	// Read source directory
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return fmt.Errorf("failed to read source directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+
+		if entry.IsDir() {
+			// Recursively copy subdirectories
+			if err := copyDirectory(srcPath, dstPath); err != nil {
+				return err
+			}
+		} else {
+			// Copy file
+			if err := copyFile(srcPath, dstPath); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// copyFile copies a single file from source to destination.
+func copyFile(src, dst string) error {
+	sourceFile, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open source file: %w", err)
+	}
+	defer sourceFile.Close()
+
+	destFile, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("failed to create destination file: %w", err)
+	}
+	defer destFile.Close()
+
+	_, err = io.Copy(destFile, sourceFile)
+	if err != nil {
+		return fmt.Errorf("failed to copy file: %w", err)
+	}
+
+	// Preserve file permissions
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("failed to stat source file: %w", err)
+	}
+	return os.Chmod(dst, srcInfo.Mode())
+}
+
 // patchGoMod updates the replace directive in go.mod to point
-// to the local LabraGo API for development purposes.
-func patchGoMod(path string) error {
+// to the local LabraGo repository for development purposes.
+func patchGoMod(path string, labraRepoPath string) error {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
-	out := strings.Replace(string(data), "// REPLACE_LABRAGO_DEVELOPMENT_API", "replace github.com/GoLabra/labra => ../..", 1)
+	replaceDirective := fmt.Sprintf("replace github.com/GoLabra/labra => %s", labraRepoPath)
+	out := strings.Replace(string(data), "// REPLACE_LABRAGO_DEVELOPMENT_API", replaceDirective, 1)
 	return os.WriteFile(path, []byte(out), 0644)
 }
 
 // createAppEnvFile writes a default backend .env configuration
 // to the generated project so it can run out of the box.
 func createAppEnvFile(projectName string) error {
-	appPath := filepath.Join(projectName, "resources", "app")
-	schemaPath, _ := filepath.Abs(filepath.Join(appPath, "ent", "schema"))
-	storagePath, _ := filepath.Abs(filepath.Join(appPath, "storage"))
+	projectPath, _ := filepath.Abs(projectName)
+	schemaPath, _ := filepath.Abs(filepath.Join(projectPath, "ent", "schema"))
+	storagePath, _ := filepath.Abs(filepath.Join(projectPath, "storage"))
 	_ = os.MkdirAll(storagePath, 0755)
 
 	env := fmt.Sprintf(`# LabraGo Environment
@@ -122,7 +240,7 @@ CENTRIFUGO_API_ADDRESS=http://localhost:8000
 CENTRIFUGO_API_KEY=secretkey
 `, projectName, schemaPath, storagePath)
 
-	return os.WriteFile(filepath.Join(appPath, ".env"), []byte(env), 0644)
+	return os.WriteFile(filepath.Join(projectPath, ".env"), []byte(env), 0644)
 }
 
 // createAdminEnvFile writes the required environment variables for
@@ -138,7 +256,7 @@ NEXT_PUBLIC_GRAPHQL_ADMIN_API_URL="http://localhost:4000/admin/query"
 NEXT_PUBLIC_GRAPHQL_ADMIN_PLAYGROUND_URL="http://localhost:4000/admin/playground"
 NEXT_PUBLIC_CENTRIFUGO_URL="ws://localhost:8000/connection/websocket"`
 
-	path := filepath.Join(projectName, "resources", "admin", ".env.local")
+	path := filepath.Join(projectName, "admin", ".env.local")
 	return os.WriteFile(path, []byte(content), 0644)
 }
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -44,7 +44,7 @@ var createCmd = &cobra.Command{
 		}
 
 		// 4. Patch go.mod
-		goModPath := filepath.Join(projectName, "src", "app", "go.mod")
+		goModPath := filepath.Join(projectName, "resources", "app", "go.mod")
 		if err := patchGoMod(goModPath); err != nil {
 			log.Errorf("❌ go.mod patch failed: %v", err)
 			os.Exit(1)
@@ -61,7 +61,7 @@ var createCmd = &cobra.Command{
 		}
 
 		// 6. Go mod tidy + generate
-		appPath := filepath.Join(projectName, "src", "app")
+		appPath := filepath.Join(projectName, "resources", "app")
 		_ = cliutils.RunCommand("go", []string{"mod", "tidy"}, appPath)
 		if err := cliutils.RunCommand("go", []string{"generate", "./..."}, appPath); err != nil {
 			log.Warnf("⚠️ go generate failed, retrying...")
@@ -70,7 +70,7 @@ var createCmd = &cobra.Command{
 		}
 
 		// 7. Frontend install
-		adminPath := filepath.Join(projectName, "src", "admin")
+		adminPath := filepath.Join(projectName, "resources", "admin")
 		if _, err := os.Stat(filepath.Join(adminPath, "package.json")); err == nil {
 			log.Infof("📦 Installing frontend dependencies with %s...", packageManager)
 			_ = cliutils.RunCommand(packageManager, []string{"install"}, adminPath)
@@ -94,21 +94,21 @@ func patchGoMod(path string) error {
 	if err != nil {
 		return err
 	}
-	out := strings.Replace(string(data), "// REPLACE_LABRAGO_DEVELOPMENT_API", "replace github.com/GoLabra/labra/src/api => ../api", 1)
+	out := strings.Replace(string(data), "// REPLACE_LABRAGO_DEVELOPMENT_API", "replace github.com/GoLabra/labra => ../..", 1)
 	return os.WriteFile(path, []byte(out), 0644)
 }
 
 // createAppEnvFile writes a default backend .env configuration
 // to the generated project so it can run out of the box.
 func createAppEnvFile(projectName string) error {
-	appPath := filepath.Join(projectName, "src", "app")
+	appPath := filepath.Join(projectName, "resources", "app")
 	schemaPath, _ := filepath.Abs(filepath.Join(appPath, "ent", "schema"))
-	filesPath, _ := filepath.Abs(filepath.Join(appPath, "files"))
-	_ = os.MkdirAll(filesPath, 0755)
+	storagePath, _ := filepath.Abs(filepath.Join(appPath, "storage"))
+	_ = os.MkdirAll(storagePath, 0755)
 
 	env := fmt.Sprintf(`# LabraGo Environment
 
-SERVER_PORT=4001
+SERVER_PORT=4000
 SECRET_KEY=supersecretdevkey
 
 DSN=postgres://postgres:postgres@localhost:5432/%s?sslmode=disable
@@ -120,7 +120,7 @@ FILE_STORAGE_PROVIDER=local
 
 CENTRIFUGO_API_ADDRESS=http://localhost:8000
 CENTRIFUGO_API_KEY=secretkey
-`, projectName, schemaPath, filesPath)
+`, projectName, schemaPath, storagePath)
 
 	return os.WriteFile(filepath.Join(appPath, ".env"), []byte(env), 0644)
 }
@@ -130,14 +130,15 @@ CENTRIFUGO_API_KEY=secretkey
 func createAdminEnvFile(projectName string) error {
 	content := `NEXT_PUBLIC_BRAND_PRODUCT_NAME="Labra·GO"
 NEXT_PUBLIC_BRAND_COLOR="blue"
-NEXT_PUBLIC_GRAPHQL_API_URL="http://localhost:4001"
-NEXT_PUBLIC_GRAPHQL_QUERY_API_URL="http://localhost:4001/query"
-NEXT_PUBLIC_GRAPHQL_QUERY_SUBSCRIPTION_URL="ws://localhost:4001/query"
-NEXT_PUBLIC_GRAPHQL_QUERY_PLAYGROUND_URL="http://localhost:4001/playground"
-NEXT_PUBLIC_GRAPHQL_ENTITY_API_URL="http://localhost:4001/entity"
-NEXT_PUBLIC_GRAPHQL_ENTITY_PLAYGROUND_URL="http://localhost:4001/eplayground"`
+NEXT_PUBLIC_GRAPHQL_API_URL="http://localhost:4000"
+NEXT_PUBLIC_GRAPHQL_QUERY_API_URL="http://localhost:4000/query"
+NEXT_PUBLIC_GRAPHQL_QUERY_SUBSCRIPTION_URL="ws://localhost:4000/query"
+NEXT_PUBLIC_GRAPHQL_QUERY_PLAYGROUND_URL="http://localhost:4000/playground"
+NEXT_PUBLIC_GRAPHQL_ADMIN_API_URL="http://localhost:4000/admin/query"
+NEXT_PUBLIC_GRAPHQL_ADMIN_PLAYGROUND_URL="http://localhost:4000/admin/playground"
+NEXT_PUBLIC_CENTRIFUGO_URL="ws://localhost:8000/connection/websocket"`
 
-	path := filepath.Join(projectName, "src", "admin", ".env")
+	path := filepath.Join(projectName, "resources", "admin", ".env.local")
 	return os.WriteFile(path, []byte(content), 0644)
 }
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -28,12 +28,12 @@ var startCmd = &cobra.Command{
 
 		// Start backend and frontend processes
 		backendCmd := exec.Command("go", "run", "main.go")
-		backendCmd.Dir = filepath.Join("resources", "app")
+		backendCmd.Dir = "." // Project root is now the app root
 		backendStdout, _ := backendCmd.StdoutPipe()
 		backendStderr, _ := backendCmd.StderrPipe()
 
 		frontendCmd := exec.Command("yarn", "dev")
-		frontendCmd.Dir = filepath.Join("resources", "admin")
+		frontendCmd.Dir = filepath.Join("admin")
 		frontendStdout, _ := frontendCmd.StdoutPipe()
 		frontendStderr, _ := frontendCmd.StderrPipe()
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -27,13 +27,13 @@ var startCmd = &cobra.Command{
 		ensureYarnNodeModules(".")
 
 		// Start backend and frontend processes
-		backendCmd := exec.Command("go", "run", "main.go", "start")
-		backendCmd.Dir = filepath.Join("src", "app")
+		backendCmd := exec.Command("go", "run", "main.go")
+		backendCmd.Dir = filepath.Join("resources", "app")
 		backendStdout, _ := backendCmd.StdoutPipe()
 		backendStderr, _ := backendCmd.StderrPipe()
 
 		frontendCmd := exec.Command("yarn", "dev")
-		frontendCmd.Dir = filepath.Join("src", "admin")
+		frontendCmd.Dir = filepath.Join("resources", "admin")
 		frontendStdout, _ := frontendCmd.StdoutPipe()
 		frontendStderr, _ := frontendCmd.StderrPipe()
 
@@ -85,7 +85,7 @@ var startCmd = &cobra.Command{
 			}
 			results <- status{name: name, ok: false, addr: addr}
 		}
-		go check("backend", "127.0.0.1:4001")
+		go check("backend", "127.0.0.1:4000")
 		go check("frontend", "127.0.0.1:3000")
 
 		b := <-results


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches project scaffolding to cached template copy with root/admin layout and updates env/start to run backend on port 4000.
> 
> - **Create flow (`cmd/create.go`)**:
>   - Clone `github.com/GoLabra/labra` into cache (`~/.cache/labractl/labra[-<ref>]`) and copy `resources/app/*` to project root and `resources/admin/*` to `admin/`.
>   - Patch `go.mod` to `replace github.com/GoLabra/labra => <cached-path>`.
>   - Run `go mod tidy` and `go generate` in project root; install frontend deps in `admin/`.
>   - New helpers: `copyDirectory` and `copyFile`.
> - **Project structure & envs**:
>   - App root is project root; admin app in `admin/`.
>   - Backend `.env` now at project root; frontend uses `admin/.env.local`.
>   - Rename `FILE_STORAGE_PATH` dir to `storage/`; `SERVER_PORT=4000`.
> - **Start command (`cmd/start.go`)**:
>   - Run backend via `go run main.go` in project root; frontend from `admin/`.
>   - Health check backend on `127.0.0.1:4000`.
> - **Docs (`README.md`)**:
>   - Update ports/URLs to `4000` and describe new cached-template creation steps and env file locations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4fc80c497b853424283f8aacc4f24c2186a13d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->